### PR TITLE
Add minimum Sidekiq version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This endpoint will detect which supported queue frameworks your application uses
 - How many jobs are currently being processed in a given queue
 
 The supported queue frameworks are:
-- [Sidekiq](https://github.com/sidekiq/sidekiq)
+- [Sidekiq (7+)](https://github.com/sidekiq/sidekiq)
 - [Resque](https://github.com/resque/resque)
 - [Delayed Job](https://github.com/collectiveidea/delayed_job) (via the [ActiveRecord backend](https://github.com/collectiveidea/delayed_job_active_record))
 


### PR DESCRIPTION
The auto mount behaviour checks for a constant `Sidekiq::WorkSet`, which as far as I can tell was added in Sidekiq 7. We should make this obvious for people running older sidekiq versions.

I think updating the readme is a good start, but maybe the gem should fail noisily if it detects an invalid Sidekiq version rather than silently failing to mount.